### PR TITLE
ci: publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - 'release/*.*.x'
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install Node dependencies
+        run: npm ci --no-audit --no-optional
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: ./dist/package.json
+          token: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ In the following example we assume that the version 1.1.0 is being released:
 
 3.  Create a new branch `release/1.1.x`, push to origin.
 
+4.  GitHub Actions will publish to registry automatically.
+
 ### Release a patch version (example)
 
 In the following example we assume that the version 1.0.1 is being released:
@@ -87,3 +89,5 @@ In the following example we assume that the version 1.0.1 is being released:
 2.  Cherry-pick required fixes from `main`.
 
 3.  Run `npm run release`, then follow instructions to push.
+
+4.  GitHub Actions will publish to registry automatically.


### PR DESCRIPTION
"Publish" workflow builds the package and deploys it to official npm registry.

Runs only on `release/*.*.x` branches, publishes only when a version is different from the one on the registry.

You can inspect [Actions](https://github.com/onfido/castor-icons/actions) to note that it is executed (test version without publishing) only on required branch: https://github.com/onfido/castor-icons/actions/runs/383365377