### PR TITLE
fix(package): set license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@onfido/castor-icons",
   "version": "0.0.0",
   "author": "Onfido",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/onfido/castor-icons.git"


### PR DESCRIPTION
We need to identify type of license we use for the package on `package.json` file too.