### PR TITLE
chore: make yarn warning easier to notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": ">= 14",
-    "yarn": "please-use-npm"
+    "yarn": "\n\n\u001b[1;31m[ERROR]\u001b[0;32m Please use npm instead!\u001b[0m\n\n"
   },
   "scripts": {
     "build": "ts-node scripts/build.ts",


### PR DESCRIPTION
This is just a suggestion, here's a preview:

![Screenshot 2020-11-26 at 13 01 52](https://user-images.githubusercontent.com/18623773/100354398-09e73e80-2fe8-11eb-8620-d192656ea197.png)

It reads more poorly in `package.json`, but it reads better in the command line.