### PR TITLE
chore: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## Purpose

Dependabot is used to keep dependencies up to date.

## Approach

Configuring Dependabot based on: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

## Testing

We will have to wait and see if PRs are being opened.

## Risks

N/A
