### PR TITLE
ci: commitlint exclude dependabot

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
         run: npm ci --no-audit --no-optional
 
       - name: Run commitlint
+        if: github.actor != 'dependabot[bot]' # allow long commit message body
         run: npm run lint:commit
 
       - name: Run all other linters


### PR DESCRIPTION
## Purpose

Dependabot sometimes [creates really long commits](https://github.com/onfido/castor-icons/pull/11) but that's not always bad.

## Approach

Exclude running commitlint for Dependabot, to allow long commits.

## Testing

On Dependabot MRs.

## Risks

N/A
