### PR TITLE
chore: release 1.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.0.0 (2020-11-27)
+
+Initial release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,23 +68,25 @@ If you need to override SemVer behavior (not recommended):
 
 The last line of the script's log will give you the command you need to execute to push the commit and tag.
 
-### Release a major/minor version (example)
+### Release a major version (example)
 
-In the following example we assume that the version 1.1.0 is being released:
+In the following example we assume that the version 2.0.0 is being released:
 
 1.  Ensure your tree is clean and run `git checkout main && git pull`.
 
-2.  Run `npm run release`, then follow instructions to push.
+2.  Create a new branch `release/2.x.x`, push to origin.
 
-3.  Create a new branch `release/1.1.x`, push to origin.
+3.  Run `npm run release`, then follow instructions to push.
 
 4.  GitHub Actions will publish to registry automatically.
 
-### Release a patch version (example)
+5.  Create a pull request to merge the major version bump back to `main`.
+
+### Release a minor/patch version (example)
 
 In the following example we assume that the version 1.0.1 is being released:
 
-1.  Checkout branch `git checkout release/1.0.x`.
+1.  Checkout branch `git checkout release/1.x.x`.
 
 2.  Cherry-pick required fixes from `main`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,11 @@ Simply run this script in the root to cut a new release:
 
 Optionally you can mark it as pre-release, e.g. `1.0.0-alpha.0`
 
-    npm run release --prerelease alpha
+    npm run release -- --prerelease alpha
 
 If you need to override SemVer behavior (not recommended):
 
-    npm run release --release-as 1.1.0
+    npm run release -- --release-as 1.1.0
 
 The last line of the script's log will give you the command you need to execute to push the commit and tag.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/castor-icons",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/castor-icons",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Collection of icons for Castor.",
   "author": "Onfido",
   "license": "Apache-2.0",


### PR DESCRIPTION
https://www.npmjs.com/package/@onfido/castor-icons/v/1.0.0

Merging version bump (and some other changes) back to the `main` branch.