### PR TITLE
chore: npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Castor Icons
+# Castor Icons &middot; [![npm version](https://img.shields.io/npm/v/@onfido/castor-icons.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-icons)
 
 This is _Castor_ addition providing a collection of selected [Boxicons](https://boxicons.com/) and custom icons.
 


### PR DESCRIPTION
## Purpose

We're publishing package on npm registry but no easy way to know what's the latest version published.

## Approach

Adding a badge to show the latest npm version published.

## Testing

On the package description.

## Risks

N/A
