### PR TITLE
ci: correct "build" job name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'release/*.*.x' # already building package when publishing
 
 jobs:
-  publish:
+  build:
     name: Build package (test)
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Purpose

Bad copy/paste - "build" job name accidently set as "publish".

## Approach

Rename job to be "build".

## Testing

N/A

## Risks

N/A
