### PR TITLE
chore: rename lint:ts to lint:es

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build": "ts-node scripts/build.ts",
     "lint": "concurrently npm:lint:*",
     "lint:commit": "commitlint --from origin/main --to HEAD --verbose",
+    "lint:es": "eslint . --ignore-path .gitignore --max-warnings 0",
     "lint:prettier": "prettier . --check --ignore-path .gitignore",
-    "lint:ts": "eslint . --ignore-path .gitignore --max-warnings 0",
     "release": "HUSKY_SKIP_HOOKS=true standard-version"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose

We're using ESLint that lints both TS and JS files, so naming script to `lint:es` is more appropriate.

## Approach

Rename script `lint:ts` to `lint:es`.

## Testing

Locally by running a script.

## Risks

N/A
