### PR TITLE
ci: preview on pull request

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Preview
 
 on:
-  pull_request_target:
+  pull_request:
     branches-ignore:
       - 'release/*.*.x'
 


### PR DESCRIPTION
## Purpose

As described on https://github.com/onfido/castor-icons/issues/53, we cannot use `pull_request_target` handler.

## Approach

Temporary switch to only using `pull_request`, until switched to new preview provider.

## Testing

Once PR merged.

## Risks

N/A
