### PR TITLE
chore: add missing changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,7 @@ All notable changes to this project will be documented in this file. See [standa
 ## 1.0.0 (2020-11-27)
 
 Initial release.
+
+### Bug Fixes
+
+- **package:** set license ([#2](https://github.com/onfido/castor-icons/issues/2)) ([c7d2037](https://github.com/onfido/castor-icons/commit/c7d2037987200a2b40c9d933231c01038108bfeb))


### PR DESCRIPTION
## Purpose

Originally upon v1.0.0 release this automated changelog entry was removed manually, now each time trying to release it is added to latest version changes.

Has also been discussed [here](https://github.com/onfido/castor-icons/commit/27f38d4b4d49cd8719c67513887854d3ec5dcec7#r45920345).

## Approach

Add original entry back to v1.0.0 release to avoid future issues.

## Testing

Upon next release.

## Risks

N/A
