### PR TITLE
docs: improve examples with react fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Every SVG icon is also exported as React component, e.g. "passport":
 
 ```jsx
 import { IconPassport } from '@onfido/castor-icons';
+import React, { Fragment } from 'react';
 
 const Component = () => (
-  <>
+  <Fragment>
     <IconPassport />
-  </>
+    {/* ...anything else e.g. text */}
+  </Fragment>
 );
 ```
 
@@ -58,12 +60,13 @@ But if you prefer to use a sprite, feel free to (only once) inline it in your ap
 
 ```jsx
 import { Icons } from '@onfido/castor-icons';
+import React, { Fragment } from 'react';
 
 const App = () => (
-  <>
+  <Fragment>
     <Icons />
     {/* ...anything else e.g. app routes */}
-  </>
+  </Fragment>
 );
 ```
 


### PR DESCRIPTION
## Purpose

React `Fragment` is not properly styled when on GitHub docs.

## Approach

Instead of shorthand using full `<Fragment />` component. Also, showing inclusion of React itself in examples.

<img width="862" alt="Screenshot 2021-01-14 at 10 38 53" src="https://user-images.githubusercontent.com/20243687/104565276-f3eb1700-5643-11eb-8329-4fb9561800d4.png">

## Testing

On GitHub itself.

## Risks

N/A
