### PR TITLE
feat!: remove grid

### DIFF
--- a/src/icons.json
+++ b/src/icons.json
@@ -46,7 +46,6 @@
   "gift": "node_modules/boxicons/svg/regular/bx-gift.svg",
   "glasses": "node_modules/boxicons/svg/regular/bx-glasses.svg",
   "google": "node_modules/boxicons/svg/logos/bxl-google.svg",
-  "grid": "node_modules/boxicons/svg/regular/bx-grid.svg",
   "grid-solid": "node_modules/boxicons/svg/solid/bxs-grid.svg",
   "group": "node_modules/boxicons/svg/regular/bx-group.svg",
   "hide": "node_modules/boxicons/svg/regular/bx-hide.svg",


### PR DESCRIPTION
## Purpose

"grid" icon will not be used.

## Approach

Remove "grid" icon.

## Testing

On preview.

## Risks

BREAKING CHANGE: Use "grid-solid" instead of "grid" icon.
