### PR TITLE
build: simplify release process

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,9 +1,6 @@
 name: Preview
 
-on:
-  pull_request:
-    branches-ignore:
-      - 'release/*.*.x'
+on: pull_request
 
 jobs:
   preview:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish
 
 on:
   push:
-    branches:
-      - 'release/*.*.x'
+    tags:
+      - 'v*.*.*'
 
 jobs:
   publish:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,6 @@ git cherry-pick c6da29b
 # use automated release script
 npm run release
 
-# push to trigger 'publish' GitHub Action
+# push to let newly created tag trigger 'publish' GitHub Action
 git push --follow-tags -u origin release/1.x.x
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ If you need to override SemVer behavior (not recommended):
 
 The last line of the script's log will give you the command you need to execute to push the commit and tag.
 
-### Release latest version (example)
+### Release the latest version
 
 You will need `main` branch push permissions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ git checkout v1.2.0
 # create release branch according to format
 git branch release/1.x.x
 
-# cherry-pick required fixes from `main`
+# cherry-pick required fixes from 'main'
 git cherry-pick c6da29b
 # pick appropriate commit hashes and repeat as needed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ git reset --hard
 # get all latest changes from remote
 git fetch --all --prune
 
-# checkout latest available version tag
+# checkout latest available version tag for v1.x.x
 git checkout v1.2.0
 
 # create release branch according to format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,28 +72,58 @@ If you need to override SemVer behavior (not recommended):
 
 The last line of the script's log will give you the command you need to execute to push the commit and tag.
 
-### Release a major version (example)
+### Release latest version (example)
 
-In the following example we assume that the version 2.0.0 is being released:
+You will need `main` branch push permissions.
 
-1.  Ensure your tree is clean and run `git checkout main && git pull`.
+```sh
+# ensure tree is clean - WARNING: will delete pending changes
+git reset --hard
 
-2.  Create a new branch `release/2.x.x`, push to origin.
+# get all latest changes from remote
+git fetch --all --prune
 
-3.  Run `npm run release`, then follow instructions to push.
+# checkout latest 'main'
+git checkout main
+git pull
 
-4.  GitHub Actions will publish to registry automatically.
+# use automated release script
+npm run release
 
-5.  Create a pull request to merge the major version bump back to `main`.
+# push to trigger 'publish' GitHub Action
+git push --follow-tags
+```
 
-### Release a minor/patch version (example)
+### Release a non-latest minor/patch version (example)
 
-In the following example we assume that the version 1.0.1 is being released:
+You will need `release/*.x.x` branch push permissions.
 
-1.  Checkout branch `git checkout release/1.x.x`.
+In the following example we assume that:
 
-2.  Cherry-pick required fixes from `main`.
+- the latest version is 2.0.1
+- the version 1.2.1 is being released
+- we'll cherry-pick hotfixes from 2.0.1 onto 1.2.0
 
-3.  Run `npm run release`, then follow instructions to push.
+```sh
+# ensure tree is clean - WARNING: will delete pending changes
+git reset --hard
 
-4.  GitHub Actions will publish to registry automatically.
+# get all latest changes from remote
+git fetch --all --prune
+
+# checkout latest available version tag
+git checkout v1.2.0
+
+# create release branch according to format
+git branch release/1.x.x
+
+# cherry-pick required fixes from `main`
+git cherry-pick c6da29b
+# pick appropriate commit hashes and repeat as needed
+
+# use automated release script
+npm run release
+
+# push to trigger 'publish' GitHub Action
+git push --follow-tags -u origin release/1.x.x
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ git pull
 # use automated release script
 npm run release
 
-# push to trigger 'publish' GitHub Action
+# push to let newly created tag trigger 'publish' GitHub Action
 git push --follow-tags
 ```
 


### PR DESCRIPTION
## Purpose

Simplify release process.

## Approach

Run 'publish' action on tags instead of branches, which makes the requirement for branches unimportant.

## Testing

After merging with main, follow the new instructions in `CONTRIBUTING.md` and check `npm` for the new version.

## Risks

1. I don't think we can protect tags in GitHub
2. Still requires branches for non-latest/diverging versions, e.g.

```
* chore(release): 2.0.1 (tag: v2.0.1)
* fix: foo
* chore(release): 2.0.0 (tag: v2.0.0)
* feat!: breaking change
|  * chore(release): 1.2.1 (tag: v1.2.1, release/1.x.x)
|  * fix: foo (tag: v1.2.1)
| /
* chore(release): 1.2.0 (tag: v1.2.0)
```
