### PR TITLE
build: fix husky v5 integration

### DIFF
--- a/.husky/.gitignore
+++ b/.husky/.gitignore
@@ -1,0 +1,2 @@
+# Husky executable
+_

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx commitlint --verbose --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+exec < /dev/tty && npx cz --hook || true

--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,7 +1,0 @@
-{
-  "hooks": {
-    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS --verbose",
-    "pre-commit": "lint-staged",
-    "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@onfido/castor-icons",
       "version": "2.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "^11.0.0",
@@ -5908,6 +5909,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "yarn": "\n\n\u001b[1;31m[ERROR]\u001b[0;32m Please use npm instead!\u001b[0m\n\n"
   },
   "scripts": {
+    "postinstall": "husky install",
     "build": "ts-node scripts/build.ts",
     "preview": "http-server -o",
     "lint": "concurrently npm:lint:*",
@@ -25,7 +26,7 @@
     "lint:es": "eslint . --ignore-path .gitignore --max-warnings 0",
     "lint:style": "stylelint '**/*.{css,html}' --ignore-path .gitignore --max-warnings 0",
     "lint:prettier": "prettier . --check --ignore-path .gitignore",
-    "release": "HUSKY_SKIP_HOOKS=true standard-version"
+    "release": "HUSKY=0 standard-version"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",


### PR DESCRIPTION
## Purpose

Following [upgrade to Husky v5](https://github.com/onfido/castor-icons/pull/87) hooks no longer work.

## Approach

Unable to use [automated upgrade script](https://github.com/typicode/husky-4-to-5), so instead switcking manually by following [migration gruide](https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v5).

## Testing

Locally only.

## Risks

N/A
