### PR TITLE
build: use default .gitignore for husky

### DIFF
--- a/.husky/.gitignore
+++ b/.husky/.gitignore
@@ -1,2 +1,1 @@
-# Husky executable
 _


### PR DESCRIPTION
## Purpose

Husky v5 integration [was fixed](https://github.com/onfido/castor-icons/pull/92) however `.gitignore` file was edited - Husky does not like this, as each time the file is force-generated.

## Approach

Use default auto-generated `.gitignore` file.

## Testing

`npm install` should not edit `.husky/.gitignore`.

## Risks

Nothing apart annoyance :hurtrealbad: 
