### PR TITLE
docs: remove duplicate changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,10 @@ All notable changes to this project will be documented in this file. See [standa
 ### Features
 
 - add bounce ([#59](https://github.com/onfido/castor-icons/issues/59)) ([03d1eeb](https://github.com/onfido/castor-icons/commit/03d1eebca9aaba8953271ffb44c3996dc1ee3f17))
-- add circle-solid ([#27](https://github.com/onfido/castor-icons/issues/27)) ([e1fccef](https://github.com/onfido/castor-icons/commit/e1fccefa349fb129f95c3c0396e51f0b45caa749))
 - add grid ([#56](https://github.com/onfido/castor-icons/issues/56)) ([38a48ef](https://github.com/onfido/castor-icons/commit/38a48eff8fcd95e492d092a00280d1a528a8f18c))
 - add pause ([#57](https://github.com/onfido/castor-icons/issues/57)) ([fedd36f](https://github.com/onfido/castor-icons/commit/fedd36f250b357784f1a2326d580c05bb5414e79))
 - add refresh ([#55](https://github.com/onfido/castor-icons/issues/55)) ([27f6077](https://github.com/onfido/castor-icons/commit/27f6077c5075f6046d18891c4f58af4c733b76ad))
 - add rotate-right ([#58](https://github.com/onfido/castor-icons/issues/58)) ([247d0b3](https://github.com/onfido/castor-icons/commit/247d0b3421f3a700edd28db9151bdd7b6c510238))
-- add sync icon ([#35](https://github.com/onfido/castor-icons/issues/35)) ([0be5c49](https://github.com/onfido/castor-icons/commit/0be5c497bd521ad141a3b0191d7e3c1ff1859b20))
 
 ## 1.1.0 (2020-12-15)
 


### PR DESCRIPTION
## Purpose

Duplicate changelog entries added with [v1.2.0 release](https://github.com/onfido/castor-icons/pull/60).

## Approach

Remove duplicate entries.

## Testing

On GitHub when merged.

## Risks

This does not make a change to released versions (incl. tags), will only affect future releases.
