### PR TITLE
ci: use custom lint commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,18 +24,11 @@ jobs:
         if: github.actor != 'dependabot[bot]' # allow long commit message body
         run: npm run lint:commit
 
-      - name: Run all other linters
-        uses: wearerequired/lint-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Enable and configure linters:
-          eslint: true
-          eslint_args: '--ignore-path .gitignore --max-warnings 0'
-          eslint_extensions: 'js,jsx,ts,tsx'
-          stylelint: true
-          stylelint_args: '--ignore-path .gitignore --max-warnings 0'
-          stylelint_extensions: 'css,html'
-          prettier: true
-          prettier_args: '--ignore-path .gitignore'
-          # Additionally configure action:
-          commit_message: 'style: fix code issues with ${linter}'
+      - name: Run stylelint
+        run: npm run lint:style
+
+      - name: Run ESLint
+        run: npm run lint:es
+
+      - name: Run Prettier
+        run: npm run lint:prettier


### PR DESCRIPTION
## Purpose

Switch to using our own custom commands to run varioius linters.

We don't use features provided by the linting action, and also this creates problems with PRs made out of forks.

## Approach

Don't use action, run individual custom commands on a workflow.

## Testing

Once merged to the `main` branch.

## Risks

N/A
