### PR TITLE
ci: commitlint exclude dependabot (preview)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm ci --no-audit --no-optional
 
       - name: Run commitlint
-        if: github.actor != 'dependabot[bot]' # allow long commit message body
+        if: github.actor != 'dependabot-preview[bot]' # allow long commit message body
         run: npm run lint:commit
 
       - name: Run stylelint


### PR DESCRIPTION
## Purpose

Based on https://github.com/onfido/castor-icons/pull/142 we now use Dependabot Preview that has a different commit actor.

## Approach

Change Dependabot actor from `dependabot` to `dependabot-preview`.

## Testing

Only after merge - rebased [Dependabot PR](https://github.com/onfido/castor-icons/pull/143) should not be failing anymore.

## Risks

N/A
