### PR TITLE
docs: clean heading for better index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Castor Icons &middot; [![npm version](https://img.shields.io/npm/v/@onfido/castor-icons.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-icons)
+# Castor Icons
+
+[![npm version](https://img.shields.io/npm/v/@onfido/castor-icons.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-icons)
 
 This is _Castor_ addition providing a collection of selected [Boxicons](https://boxicons.com/) and custom icons.
 


### PR DESCRIPTION
## Purpose

After GitHub introducing built-in index (table of content), our current heading included additional symbols resulting in odd appearance in UI:

![Screenshot 2021-04-06 at 10 46 36](https://user-images.githubusercontent.com/20243687/113692350-5ee93e80-96c5-11eb-961b-4453cef649c8.png)

## Approach

Move "dot" alongside badge to a newline after the heading.

## Testing

On https://github.com/onfido/castor-icons/tree/docs/better-gh-index

## Risks

N/A
