### PR TITLE
docs: add badge to indicate bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Castor Icons
 
-[![npm version](https://img.shields.io/npm/v/@onfido/castor-icons.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-icons)
+[![npm version](https://badgen.net/npm/v/@onfido/castor-icons)](https://www.npmjs.com/package/@onfido/castor-icons)
+[![Bundle size](https://badgen.net/bundlephobia/minzip/@onfido/castor-icons)](https://bundlephobia.com/result?p=@onfido/castor-icons)
 
 This is _Castor_ addition providing a collection of selected [Boxicons](https://boxicons.com/) and custom icons.
 


### PR DESCRIPTION
## Purpose

New badge to indicate bundle size.

## Approach

Use [bundlephobia](https://github.com/pastelsky/bundlephobia) to analyze and display minzipped size.

## Testing

On https://github.com/onfido/castor-icons/tree/docs/bundle-size-badge

## Risks

N/A
