### PR TITLE
build: correctly bump version in package-lock.json file

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,5 +1,11 @@
 {
-  "bumpFiles": ["package.json", "package-lock.json"],
+  "bumpFiles": [
+    "package.json",
+    {
+      "filename": "package-lock.json",
+      "updater": "scripts/bump-package-lock.cjs"
+    }
+  ],
   "scripts": {
     "postchangelog": "prettier CHANGELOG.md -w"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@onfido/castor-icons",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/scripts/bump-package-lock.cjs
+++ b/scripts/bump-package-lock.cjs
@@ -1,0 +1,19 @@
+// can't be `bump-package-lock.ts` as it is invoked by `standard-version` as a
+// custom updater
+
+const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+
+module.exports.readVersion = function (contents) {
+  return JSON.parse(contents).packages[''].version;
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const json = JSON.parse(contents);
+  const indent = detectIndent(contents).indent;
+  const newline = detectNewline(contents);
+  json.version = version;
+  json.packages[''].version = version;
+  return stringifyPackage(json, indent, newline);
+};


### PR DESCRIPTION
## Purpose

npm workspace version bump in `package-lock.json` requires version to be bumped in 2 places.

## Approach

Bumping cannot be done by just specifying a file, instead a custom bumper has to be used, same as on https://github.com/onfido/castor/pull/234 and https://github.com/onfido/castor-tokens/pull/13.

## Testing

`npm run release -- --dry-run`

## Risks

N/A
