### PR TITLE
build: lint ts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Run ESLint
         run: npm run lint:es
 
+      - name: Run tsc (type check)
+        run: npm run lint:ts
+
       - name: Run Prettier
         run: npm run lint:prettier

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "concurrently npm:lint:*",
     "lint:commit": "commitlint --from origin/main --to HEAD --verbose",
     "lint:es": "eslint . --ignore-path .gitignore --max-warnings 0",
+    "lint:ts": "tsc --noEmit",
     "lint:style": "stylelint '**/*.{css,html}' --ignore-path .gitignore --max-warnings 0",
     "lint:prettier": "prettier . --check --ignore-path .gitignore",
     "release": "HUSKY=0 standard-version"

--- a/tsconfig.generated.json
+++ b/tsconfig.generated.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "include": ["dist/tsx/*"],
+  "exclude": [],
   "compilerOptions": {
     "outDir": "dist/js",
-    "sourceMap": true
+    "sourceMap": true,
+    "skipLibCheck": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["**/*"],
+  "exclude": ["node_modules/**/*", "dist/**/*"],
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": false,
@@ -7,7 +8,7 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "strictNullChecks": true,
 
     "module": "esnext",


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/718, catch TS (type) errors ahead of time.

## Approach

Run `tsc --noEmit` on lint.

## Testing

Locally, on CI.

## Risks

Had to ignore a lib check, otherwise no way to ignore `@types` from `node_modules`, where `svg-sprite` is failing:

<img width="1437" alt="Screenshot 2021-06-01 at 09 57 03" src="https://user-images.githubusercontent.com/20243687/120296137-b966db80-c2bf-11eb-8a3d-0eee804d0da6.png">
