### PR TITLE
build: automatically sort imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
         "prettier": "^2.2.0",
+        "prettier-plugin-organize-imports": "^2.1.0",
         "standard-version": "^9.0.0",
         "stylelint": "^13.8.0",
         "stylelint-config-standard": "^22.0.0",
@@ -8162,6 +8163,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.1.0.tgz",
+      "integrity": "sha512-P6TzXkuZRV4g9Fl363tN+r6/ecynu0fwmItKCb/04iksrUtwl/6Jf4DxBPuW8UbcgFRadltxB0VlV5Yh1Ec0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
       }
     },
     "node_modules/prettysize": {
@@ -17484,6 +17496,13 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
       "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
+    },
+    "prettier-plugin-organize-imports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.1.0.tgz",
+      "integrity": "sha512-P6TzXkuZRV4g9Fl363tN+r6/ecynu0fwmItKCb/04iksrUtwl/6Jf4DxBPuW8UbcgFRadltxB0VlV5Yh1Ec0Ow==",
+      "dev": true,
+      "requires": {}
     },
     "prettysize": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.2.0",
+    "prettier-plugin-organize-imports": "^2.1.0",
     "standard-version": "^9.0.0",
     "stylelint": "^13.8.0",
     "stylelint-config-standard": "^22.0.0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,15 +1,15 @@
 import { spawnSync } from 'child_process';
+import { loopWhile } from 'deasync';
 import {
+  appendFileSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
-  appendFileSync,
-  copyFileSync,
 } from 'fs';
-import { resolve, join } from 'path';
 import { glob } from 'glob';
-import { loopWhile } from 'deasync';
+import { join, resolve } from 'path';
 import SVGSpriter from 'svg-sprite';
 import icons from '../src/icons.json';
 


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/202, sorting imports automatically.

## Approach

Sort with Prettier using `prettier-plugin-organize-imports`.

## Testing

N/A

## Risks

N/A
