### PR TITLE
build: rename ts index extension from *.tsx to *.ts

### DIFF
--- a/tsconfig.generated.json
+++ b/tsconfig.generated.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["dist/tsx/*"],
+  "include": ["dist/ts/*"],
   "exclude": [],
   "compilerOptions": {
     "outDir": "dist/js",


### PR DESCRIPTION
## Purpose

Use `index.ts` instead of `index.tsx` for main export + types.

Should fix https://github.com/onfido/castor-icons/issues/272.

## Approach

Rename auto-generated `index.tsx` to `index.ts` during the build.

Also rename directory from `tsx` to just `ts`.

## Testing

Tested locally.

## Risks

N/A
