### PR TITLE
fix: build with react-jsx

### DIFF
--- a/.svgrrc.json
+++ b/.svgrrc.json
@@ -1,5 +1,4 @@
 {
-  "svgo": false,
   "memo": true,
   "typescript": true,
   "svgProps": { "fill": "currentColor", "focusable": false }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "lint:prettier": "prettier . --check --ignore-path .gitignore",
     "release": "HUSKY=0 standard-version"
   },
+  "peerDependencies": {
+    "react": ">=17 || ^16.14 || ^15.7 || ^0.14.10"
+  },
   "devDependencies": {
     "@commitlint/cli": "^16.0.0",
     "@commitlint/config-conventional": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "url": "https://github.com/onfido/castor-icons/issues"
   },
   "homepage": "https://github.com/onfido/castor-icons",
+  "main": "js/index.js",
+  "types": "ts/index.ts",
+  "module": "js/index.js",
+  "sideEffects": false,
   "engines": {
     "node": ">= 14",
     "npm": ">= 7",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -167,6 +167,7 @@ writeFileSync(
           'repository',
           'bugs',
           'homepage',
+          'peerDependencies',
         ].includes(key)
       )
     ),

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -155,29 +155,32 @@ const packageFileData = JSON.parse(readFileSync(packageFileSrc).toString());
 
 writeFileSync(
   packageFileDest,
-  JSON.stringify({
-    ...Object.fromEntries(
-      Object.entries(packageFileData).filter(([key]) =>
-        [
-          'name',
-          'version',
-          'description',
-          'author',
-          'license',
-          'repository',
-          'bugs',
-          'homepage',
-          'peerDependencies',
-        ].includes(key)
-      )
-    ),
-    main: 'js/index.js',
-    types: 'ts/index.ts',
-    // all below needed to make sure that webpack can properly tree-shake
-    type: 'module',
-    module: 'js/index.js',
-    sideEffects: false,
-  })
+  JSON.stringify(
+    {
+      ...Object.fromEntries(
+        Object.entries(packageFileData).filter(([key]) =>
+          [
+            'name',
+            'version',
+            'description',
+            'author',
+            'license',
+            'repository',
+            'bugs',
+            'homepage',
+            'main',
+            'types',
+            'module',
+            'sideEffects',
+            'peerDependencies',
+          ].includes(key)
+        )
+      ),
+      type: 'module',
+    },
+    null,
+    2
+  )
 );
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "target": "es2019",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
 
     "lib": ["esnext", "dom"]
   },


### PR DESCRIPTION
## Purpose

Due to a bug in `svgr` it does not emit `import React` as it would be necessary for runtime execution of the components

## Approach

Build with TypeScript's `react: "react-jsx"` new transform instead so necessary imports are correctly inserted

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#jsx-factories

## Testing

New components work in runtime, old ones didn't

## Risks

Requires `react: >=17 || ^16.14 || ^15.7 || ^0.14.10` but previously we did not specify any necessary versions
