### PR TITLE
feat: add plus-circle

### DIFF
--- a/src/icons.json
+++ b/src/icons.json
@@ -91,6 +91,7 @@
   "play": "node_modules/boxicons/svg/regular/bx-play.svg",
   "play-store": "node_modules/boxicons/svg/logos/bxl-play-store.svg",
   "plus": "node_modules/boxicons/svg/regular/bx-plus.svg",
+  "plus-circle": "node_modules/boxicons/svg/regular/bx-plus-circle.svg",
   "polygon": "node_modules/boxicons/svg/regular/bx-shape-polygon.svg",
   "pulse": "node_modules/boxicons/svg/regular/bx-pulse.svg",
   "question-mark": "node_modules/boxicons/svg/regular/bx-question-mark.svg",


### PR DESCRIPTION
## Purpose

New "plus-circle" icon.

## Approach

Add "plus-circle" icon from Boxicons.

## Testing

On preview.

## Risks

N/A
